### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides web and image search capabilities through Google's Custom Search API. This server follows the MCP specification to integrate with Claude and other AI assistants.
 
+<a href="https://glama.ai/mcp/servers/@hunter-arton/google_search_mcp_server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hunter-arton/google_search_mcp_server/badge" alt="Google Search Server MCP server" />
+</a>
+
 ## What We're Building
 
 Many AI assistants don't have up-to-date information or the ability to search the web. This MCP server solves that problem by providing two tools:


### PR DESCRIPTION
This PR adds a badge for the [Google Search MCP Server](https://glama.ai/mcp/servers/@hunter-arton/google_search_mcp_server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@hunter-arton/google_search_mcp_server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hunter-arton/google_search_mcp_server/badge" alt="Google Search Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.